### PR TITLE
Enable building as a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1
+# See https://docs.docker.com/language/python/build-images/
+
+FROM registry.access.redhat.com/ubi9-minimal:latest
+WORKDIR /app
+COPY . .
+RUN microdnf install -y python3 python3-pip gem
+RUN pip3 install -r requirements.txt
+
+# Create a simple executable file for enki
+RUN echo '#!/bin/sh' > /usr/local/bin/enki
+RUN echo 'python3 /app/src/enki.py "$@"' >> /usr/local/bin/enki
+RUN chmod +x /usr/local/bin/enki
+
+# When running this container interactively, use `-v .:/mnt/enki:Z`
+# to mount the current directory in the host to the container working dir.
+VOLUME ["/mnt/enki"]
+WORKDIR "/mnt/enki"
+CMD ["enki"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@
 FROM registry.access.redhat.com/ubi9-minimal:latest
 WORKDIR /app
 COPY . .
-RUN microdnf install -y python3 python3-pip gem
+# findutils provides xargs
+RUN microdnf install -y findutils python3 python3-pip gem
 RUN pip3 install -r requirements.txt
 
 # Create a simple executable file for enki

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,11 @@ WORKDIR /app
 COPY . .
 # findutils provides xargs
 RUN microdnf install -y findutils python3 python3-pip gem
+# Install Python dependencies
 RUN pip3 install -r requirements.txt
+# Install Ruby dependencies
+RUN gem install bundler
+RUN bundle install --gemfile=Gemfile
 
 # Create a simple executable file for enki
 RUN echo '#!/bin/sh' > /usr/local/bin/enki

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@
 FROM registry.access.redhat.com/ubi9-minimal:latest
 WORKDIR /app
 COPY . .
+
 # findutils provides xargs
 RUN microdnf install -y findutils python3 python3-pip gem
 # Install Python dependencies

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Command-line validation tool.
     sh install.sh
     ```
 
-1. Source your `~/.baschrc` file:
+1. Source your `~/.bashrc` file:
     ```bash
     source ~/.bashrc
     ```


### PR DESCRIPTION
This PR adds Dockerfile configuration, which enables you to package enki as a container. You can either distribute it for interactive command-line use, or plug it into a CI pipeline.

On Fedora or RHEL, build the container like this:

```
podman build -t test/enki .
```

And run it like this:

```
podman run -it -v .:/mnt/enki:Z test/enki enki <arguments>
```

I'm already distributing my own build as `quay.io/msuchane/enki`, if you want a pre-built, hosted version:

```
podman run -it -v .:/mnt/enki:Z quay.io/msuchane/enki enki <arguments>
```

If you're happy with this general approach, we can discuss setting up your own repository and documenting the usage.